### PR TITLE
2 Bugfixes for ContextImpl and RootImpl

### DIFF
--- a/elements-demo/pom.xml
+++ b/elements-demo/pom.xml
@@ -5,12 +5,12 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>elements-demo</artifactId>
 	<packaging>war</packaging>
-	<version>0.2.0</version>
+	<version>0.2.1-SNAPSHOT</version>
 	<name>Elements Add-on Demo</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.5</vaadin.version>
+		<vaadin.version>8.6.2</vaadin.version>
 	</properties>
 
 	<licenses>

--- a/elements-demo/pom.xml
+++ b/elements-demo/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.6.2</vaadin.version>
+ 		<vaadin.version>8.0.5</vaadin.version>
 	</properties>
 
 	<licenses>

--- a/elements/pom.xml
+++ b/elements/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.0.5</vaadin.version>
+		<vaadin.version>8.6.2</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.8.1</version>
+			<version>1.11.2</version>
 		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>

--- a/elements/pom.xml
+++ b/elements/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>8.6.2</vaadin.version>
+ 		<vaadin.version>8.0.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->

--- a/elements/src/main/java/org/vaadin/elements/impl/Context.java
+++ b/elements/src/main/java/org/vaadin/elements/impl/Context.java
@@ -37,8 +37,9 @@ public class Context {
 
         while (!queue.isEmpty()) {
             Node soupChild = queue.poll();
-
-            queue.addAll(soupChild.childNodes());
+            if (soupChild.childNodeSize() > 0) {
+            	queue.addAll(soupChild.childNodes());
+            }
 
             NodeImpl child = ElementReflectHelper.wrap(soupChild);
             adopt(child);

--- a/elements/src/main/java/org/vaadin/elements/impl/Context.java
+++ b/elements/src/main/java/org/vaadin/elements/impl/Context.java
@@ -37,7 +37,8 @@ public class Context {
 
         while (!queue.isEmpty()) {
             Node soupChild = queue.poll();
-            if (soupChild.childNodeSize() > 0) {
+             // Only relevant for newer JSoup versions
+             if (soupChild.childNodeSize() > 0) {
             	queue.addAll(soupChild.childNodes());
             }
 

--- a/elements/src/main/java/org/vaadin/elements/impl/RootImpl.java
+++ b/elements/src/main/java/org/vaadin/elements/impl/RootImpl.java
@@ -302,23 +302,27 @@ public class RootImpl extends ElementImpl implements Root {
     private void synchronizeRecursively(JsonArray hierarchy,
             ElementImpl element) {
         int firstChild;
-        JsonValue maybeAttributes = hierarchy.get(2);
-        if (maybeAttributes.getType() == JsonType.OBJECT) {
-            firstChild = 3;
-            JsonObject attributes = (JsonObject) maybeAttributes;
-            String[] names = attributes.keys();
-
-            HashSet<String> oldAttributes = new HashSet<>(
-                    element.getAttributeNames());
-            oldAttributes.removeAll(Arrays.asList(names));
-            oldAttributes.forEach(n -> element.removeAttribute(n));
-
-            Arrays.stream(names).forEach(name -> element.setAttribute(name,
-                    attributes.getString(name)));
-        } else {
-            firstChild = 2;
+        if (hierarchy.length() > 2) {
+	        JsonValue maybeAttributes = hierarchy.get(2);
+	        if (maybeAttributes.getType() == JsonType.OBJECT) {
+	            firstChild = 3;
+	            JsonObject attributes = (JsonObject) maybeAttributes;
+	            String[] names = attributes.keys();
+	
+	            HashSet<String> oldAttributes = new HashSet<>(
+	                    element.getAttributeNames());
+	            oldAttributes.removeAll(Arrays.asList(names));
+	            oldAttributes.forEach(n -> element.removeAttribute(n));
+	
+	            Arrays.stream(names).forEach(name -> element.setAttribute(name,
+	                    attributes.getString(name)));
+	        } else {
+	            firstChild = 2;
+	        }
         }
-
+        else {
+        	firstChild = hierarchy.length();
+        }
         ArrayList<NodeImpl> newChildren = new ArrayList<>();
         for (int i = firstChild; i < hierarchy.length(); i++) {
             JsonArray child = hierarchy.getArray(i);

--- a/elements/src/test/java/org/vaadin/elements/RootTest.java
+++ b/elements/src/test/java/org/vaadin/elements/RootTest.java
@@ -86,6 +86,7 @@ public class RootTest {
 
     @Test
     public void addLeafToRootNode() {
-        root.setInnerHtml("<span>Text-Leaf</span>");
+         // Only relevant for newer JSoup versions
+         root.setInnerHtml("<span>Text-Leaf</span>");
     }
 }

--- a/elements/src/test/java/org/vaadin/elements/RootTest.java
+++ b/elements/src/test/java/org/vaadin/elements/RootTest.java
@@ -1,5 +1,7 @@
 package org.vaadin.elements;
 
+import com.vaadin.icons.VaadinIcons;
+import com.vaadin.shared.ui.ContentMode;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,4 +72,20 @@ public class RootTest {
                 pendingCommands.toJson());
     }
 
+    @Test
+    public void fetchDOMWithLeafsWithoutAttributes() {
+        // set a callback for the synchronize
+        root.fetchDom(() -> {
+            Assert.assertEquals("<div></div>", root.asHtml());
+        });
+        JsonArray pendingCommands = root.flushPendingCommands();
+
+        // synchronize structure with no children and no attributes
+        root.synchronize(0, pendingCommands);
+    }
+
+    @Test
+    public void addLeafToRootNode() {
+        root.setInnerHtml("<span>Text-Leaf</span>");
+    }
 }


### PR DESCRIPTION
Hi, 
this Pull Request suggests two bugfixes: 

ContextImpl: in the case of a LeafNode calling childNodes throws an Exception, therefore we check childNodeSize first

RootImpl: access to index 2 fails for elements with no children and no attributes because array size is 2 then containing only tagname and element id, therefore we check for length before trying access at idx 2