### PR TITLE
Remove explicit JSoup dependency

### DIFF
--- a/elements/pom.xml
+++ b/elements/pom.xml
@@ -72,11 +72,6 @@
 			<version>${vaadin.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jsoup</groupId>
-			<artifactId>jsoup</artifactId>
-			<version>1.11.2</version>
-		</dependency>
-		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib</artifactId>
 			<version>3.1</version>


### PR DESCRIPTION
The appropriate JSoup version is already included as a transitive
dependency from vaadin-server. Without an explicit dependency, the JSoup
version compatible with the used Vaadin version will be used.